### PR TITLE
support for specifying column names on insert

### DIFF
--- a/src/binder.rs
+++ b/src/binder.rs
@@ -78,7 +78,7 @@ pub struct BoundSubqueryTableReferenceAST {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct BoundInsertStatementAST {
     pub table_name: String,
-    pub column_names: Vec<String>,
+    pub column_names: Option<Vec<String>>,
     pub values: Vec<BoundExpressionAST>,
     pub first_page_id: PageID,
     pub table_schema: Schema,
@@ -441,33 +441,36 @@ impl Binder {
             .lock()
             .map_err(|_| anyhow::anyhow!("lock error"))?
             .get_schema_by_table_name(&statement.table_name, self.txn_id)?;
-        if statement.column_names.len() > 0 {
-            if statement.column_names.len() != statement.values.len() {
-                return Err(anyhow::anyhow!(
-                    "expected {} values, but got {}",
-                    statement.column_names.len(),
-                    statement.values.len()
-                ));
-            }
-            if statement.column_names.len() > schema.columns.len() {
-                return Err(anyhow::anyhow!(
-                    "expected {} values, but got {}",
-                    schema.columns.len(),
-                    statement.column_names.len()
-                ));
-            }
-            for column_name in &statement.column_names {
-                if !schema.columns.iter().any(|column| column.name == *column_name) {
-                    return Err(anyhow::anyhow!("column {} not found", column_name));
+        match &statement.column_names {
+            Some(column_names) => {
+                if column_names.len() != statement.values.len() {
+                    return Err(anyhow::anyhow!(
+                        "expected {} values, but got {}",
+                        column_names.len(),
+                        statement.values.len()
+                    ));
+                }
+                if column_names.len() > schema.columns.len() {
+                    return Err(anyhow::anyhow!(
+                        "expected {} values, but got {}",
+                        schema.columns.len(),
+                        column_names.len()
+                    ));
+                }
+                for column_name in column_names {
+                    if !schema.columns.iter().any(|column| column.name == *column_name) {
+                        return Err(anyhow::anyhow!("column {} not found", column_name));
+                    }
                 }
             }
-        } else {
-            if statement.values.len() != schema.columns.len() {
-                return Err(anyhow::anyhow!(
-                    "expected {} values, but got {}",
-                    schema.columns.len(),
-                    statement.values.len()
-                ));
+            None => {
+                if statement.values.len() != schema.columns.len() {
+                    return Err(anyhow::anyhow!(
+                        "expected {} values, but got {}",
+                        schema.columns.len(),
+                        statement.values.len()
+                    ));
+                }
             }
         }
         let mut values = Vec::new();
@@ -1307,7 +1310,7 @@ mod tests {
             bound_statement,
             BoundStatementAST::Insert(BoundInsertStatementAST {
                 table_name: "t1".to_string(),
-                column_names: vec![],
+                column_names: None,
                 values: vec![
                     BoundExpressionAST::Literal(BoundLiteralExpressionAST {
                         value: Value::Integer(IntegerValue(1)),

--- a/src/executor/insert_executor.rs
+++ b/src/executor/insert_executor.rs
@@ -29,19 +29,17 @@ impl InsertExecutor<'_> {
             .enumerate()
             .map(|(i, c)| {
                 let index;
-                if self.plan.column_names.len() > 0 {
-                    let position = self
-                        .plan
-                        .column_names
-                        .iter()
-                        .position(|x| x == &c.name);
-                    // TODO: support default value
-                    match position {
-                        Some(i) => index = i,
-                        None => return Ok(Value::Null),
+                match &self.plan.column_names {
+                    Some(column_names) => {
+                        let position = column_names.iter().position(|x| x == &c.name);
+                        match position {
+                            Some(pos) => index = pos,
+                            None => return Ok(Value::Null)
+                        }
+                    },
+                    None => {
+                        index = i;
                     }
-                } else {
-                    index = i;
                 }
                 let raw_value = self.plan.values[index].eval(
                     &vec![&Tuple::new(None, &[])],

--- a/src/executor/insert_executor.rs
+++ b/src/executor/insert_executor.rs
@@ -28,7 +28,22 @@ impl InsertExecutor<'_> {
             .iter()
             .enumerate()
             .map(|(i, c)| {
-                let raw_value = self.plan.values[i].eval(
+                let index;
+                if self.plan.column_names.len() > 0 {
+                    let position = self
+                        .plan
+                        .column_names
+                        .iter()
+                        .position(|x| x == &c.name);
+                    // TODO: support default value
+                    match position {
+                        Some(i) => index = i,
+                        None => return Ok(Value::Null),
+                    }
+                } else {
+                    index = i;
+                }
+                let raw_value = self.plan.values[index].eval(
                     &vec![&Tuple::new(None, &[])],
                     &vec![&Schema { columns: vec![] }],
                 )?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -95,6 +95,7 @@ pub struct LimitAST {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct InsertStatementAST {
     pub table_name: String,
+    pub column_names: Vec<String>,
     // TODO: support multiple rows
     pub values: Vec<ExpressionAST>,
 }
@@ -460,6 +461,20 @@ impl Parser {
         self.consume_token_or_error(Token::Keyword(Keyword::Insert))?;
         self.consume_token_or_error(Token::Keyword(Keyword::Into))?;
         let table_name = self.identifier()?;
+        // verify column names
+        let column_names = if self.consume_token(Token::LeftParen) {
+            let mut column_names = Vec::new();
+            loop {
+                column_names.push(self.identifier()?);
+                if !self.consume_token(Token::Comma) {
+                    break;
+                }
+            }
+            self.consume_token_or_error(Token::RightParen)?;
+            column_names
+        } else {
+            Vec::new()
+        };
         self.consume_token_or_error(Token::Keyword(Keyword::Values))?;
         self.consume_token_or_error(Token::LeftParen)?;
         let mut values = Vec::new();
@@ -470,7 +485,7 @@ impl Parser {
             }
         }
         self.consume_token_or_error(Token::RightParen)?;
-        Ok(InsertStatementAST { table_name, values })
+        Ok(InsertStatementAST { table_name, column_names, values })
     }
     fn delete_statement(&mut self) -> Result<DeleteStatementAST> {
         self.consume_token_or_error(Token::Keyword(Keyword::Delete))?;
@@ -956,6 +971,38 @@ mod tests {
             statement,
             StatementAST::Insert(InsertStatementAST {
                 table_name: String::from("users"),
+                column_names: vec![],
+                values: vec![
+                    ExpressionAST::Literal(LiteralExpressionAST {
+                        value: Value::Integer(IntegerValue(1)),
+                    }),
+                    ExpressionAST::Literal(LiteralExpressionAST {
+                        value: Value::Varchar(VarcharValue(String::from("foo"))),
+                    }),
+                    ExpressionAST::Literal(LiteralExpressionAST {
+                        value: Value::Boolean(BooleanValue(true)),
+                    }),
+                ],
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_insert_with_column_names() -> Result<()> {
+        let sql = "INSERT INTO users (id, name, is_deleted) VALUES (1, 'foo', true)";
+        let mut parser = Parser::new(tokenize(&mut sql.chars().peekable())?);
+
+        let statement = parser.parse()?;
+        assert_eq!(
+            statement,
+            StatementAST::Insert(InsertStatementAST {
+                table_name: String::from("users"),
+                column_names: vec![
+                    String::from("id"),
+                    String::from("name"),
+                    String::from("is_deleted"),
+                ],
                 values: vec![
                     ExpressionAST::Literal(LiteralExpressionAST {
                         value: Value::Integer(IntegerValue(1)),

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -134,7 +134,7 @@ pub struct EmptyRowPlan {
 pub struct InsertPlan {
     pub first_page_id: PageID,
     pub table_schema: Schema,
-    pub column_names: Vec<String>,
+    pub column_names: Option<Vec<String>>,
     pub values: Vec<BoundExpressionAST>,
     pub schema: Schema,
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -134,6 +134,7 @@ pub struct EmptyRowPlan {
 pub struct InsertPlan {
     pub first_page_id: PageID,
     pub table_schema: Schema,
+    pub column_names: Vec<String>,
     pub values: Vec<BoundExpressionAST>,
     pub schema: Schema,
 }
@@ -378,6 +379,7 @@ impl Planner {
         Plan::Insert(InsertPlan {
             first_page_id: insert_statement.first_page_id,
             table_schema: insert_statement.table_schema.clone(),
+            column_names: insert_statement.column_names.clone(),
             values: insert_statement.values.clone(),
             schema: Schema {
                 columns: vec![Column {


### PR DESCRIPTION
Supported specifying column names on insert statement.

```
✔ Query · create table books (id int, name varchar, description varchar);
table books created
✔ Query · insert into books VALUES (1, 'book1', 'desc1');
+----------------+
| __insert_count |
+================+
| 1              |
+----------------+

✔ Query · insert into books (name, id) VALUES ('book2', 2);
+----------------+
| __insert_count |
+================+
| 1              |
+----------------+

✔ Query · select * from books;
+----+-------+-------------+
| id | name  | description |
+====+=======+=============+
| 1  | book1 | desc1       |
+----+-------+-------------+
| 2  | book2 | NULL        |
+----+-------+-------------+
```